### PR TITLE
Fix syntax parsing bug

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -169,6 +169,7 @@ export function parse (message) {
         level -= 1
         sub = even(level)
         part = ''
+        delete cache[level + 1];
         break
       }
       default: {

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -148,6 +148,11 @@ describe('format', function () {
       expect(format(message, { value: 1 }))
         .equal('one Person')
     })
+    it('complex 1', function () {
+      const message = 'You have {count, plural, one {# unread message} other {# unread messages}}, {firstName}'
+      expect(format(message, { count: 10, firstName: 'Jane' }))
+        .equal('You have 10 unread messages, Jane')
+    })
   })
 
   describe('selectordinal', function () {


### PR DESCRIPTION
This PR addresses a bug in the parsing of nested syntax. Previously, variable references following nested syntax (such as plurals or selects) were incorrectly replaced with cached values from the block.

Changes:
- Added a failing test case to reproduce the issue
- Modified the `parse` function to clear the cache after closing syntax blocks

To test:
1. Run the newly added test case
2. Try formatting messages with nested syntax followed by variable references